### PR TITLE
Create two tests for limit block types, setup a simple global testing…

### DIFF
--- a/src/__test__/utils/default-editor-state.js
+++ b/src/__test__/utils/default-editor-state.js
@@ -1,0 +1,34 @@
+import {
+	convertFromRaw,
+	EditorState
+} from 'draft-js';
+
+export default function getDefaultEditorState (includeTypes) {
+	const defaultBlocks = [
+		{ text: 'title', type: 'header-one', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: 'sub-title', type: 'header-two', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: 'paragraph', type: 'unstyled', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: 'list-item', type: 'unordered-list-item', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: 'list-item', type: 'unordered-list-item', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: 'list-item', type: 'ordered-list-item', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: 'list-item', type: 'ordered-list-item', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: 'code', type: 'code-block', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: 'quote', type: 'blockquote', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+		{ text: ' ', type: 'atomic', depth: 0, inlineStyleRanges: [], entityRanges: [ { offset: 0, length: 1, key: 0 } ] },
+		{ text: 'closing text', type: 'unstyled', depth: 0, inlineStyleRanges: [], entityRanges: [] }
+	];
+
+	const filteredBlocks = defaultBlocks.filter(block => includeTypes.includes(block.type));
+
+	const rawContent = {
+		blocks: includeTypes.length > 0 ? filteredBlocks : defaultBlocks,
+		entityMap: {
+			0: { type: 'some-cool-embed', mutability: 'IMMUTABLE', data: { MimeType: 'some-cool-embed', test: true } }
+		}
+	};
+
+	const content = convertFromRaw(rawContent);
+	const editorState = EditorState.createWithContent(content);
+
+	return editorState;
+}

--- a/src/__test__/utils/index.js
+++ b/src/__test__/utils/index.js
@@ -1,0 +1,12 @@
+import {EditorState, convertFromRaw, convertToRaw} from 'draft-js';
+
+export getDefaultEditorState from './default-editor-state';
+
+export function getEditorState (raw) {
+	return raw ? EditorState.createWithContent(convertFromRaw(raw)) : EditorState.createEmpty();
+}
+
+export function getRawFromState (editorState) {
+	return convertToRaw(editorState.getCurrentContent());
+}
+

--- a/src/plugins/limit-block-types/utils/__test__/fix-state-for-allowed.spec.js
+++ b/src/plugins/limit-block-types/utils/__test__/fix-state-for-allowed.spec.js
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+import { getDefaultEditorState, getRawFromState, getEditorState } from '../../../../__test__/utils';
+import { BLOCKS } from '../../../../Constants';
+import fixStateForAllowed from '../fix-state-for-allowed';
+
+describe('Fix state for allowed ', () => {
+	test('all blocks are unstyled', () => {
+		const includeTypes = [BLOCKS.UNSTYLED, BLOCKS.CODE];
+		const editorState = getDefaultEditorState(includeTypes);
+		const allowed = new Set([BLOCKS.UNSTYLED]);
+
+		const fixedState = fixStateForAllowed(editorState, allowed);
+		const fixedRaw = getRawFromState(fixedState);
+
+		fixedRaw.blocks.forEach(block => {
+			expect(block.type).toBe(BLOCKS.UNSTYLED);
+		});
+	});
+	test('all blocks are unstyled or block', () => {
+		const editorState = getEditorState({
+			blocks: [
+				{ text: 'paragraph', type: 'unstyled', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+				{ text: 'code', type: 'code-block', depth: 0, inlineStyleRanges: [], entityRanges: [] },
+				{ text: 'quote', type: 'blockquote', depth: 0, inlineStyleRanges: [], entityRanges: [] }
+			],
+			entityMap: {}
+		});
+		const allowed = new Set([BLOCKS.UNSTYLED, BLOCKS.BLOCKQUOTE]);
+
+		const fixedState = fixStateForAllowed(editorState, allowed);
+		const fixedRaw = getRawFromState(fixedState);
+		const { blocks } = fixedRaw;
+
+		expect(blocks[0].type).toBe(BLOCKS.UNSTYLED);
+		expect(blocks[1].type).toBe(BLOCKS.UNSTYLED);
+		expect(blocks[2].type).toBe(BLOCKS.BLOCKQUOTE);
+	});
+});


### PR DESCRIPTION
1) Tests:
- Only block styles remain
- Allow two block style types and transform code to paragraph
2) Setup simple testing utils
Pulled some existing util functions, created a default editor state creator. 